### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ For new and future work, use the [Create OV WebRTC sample](https://docs.omnivers
 
 Rather than cloning one fixed sample, the Create OV WebRTC sample scaffolds a fresh, ready-to-run web streaming client on demand with `npx`. It tracks a pinned, versioned NVIDIA Web Streaming Library, supports local, Omniverse Kit App Streaming (OKAS), and NVCF cloud streaming backends, and lets you generate a TypeScript-only or React project.
 
+---
+
+<br/>
+
 <p align="center">
   <img src="readme-assets/sample.png" width=100% />
 </p>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Omniverse Web Viewer Sample Application
 
+## :warning: Deprecation Notice
+
+**This repository is no longer actively developed or updated, and is kept for reference only.**
+
+For new and future work, use the [Create OV WebRTC sample](https://docs.omniverse.nvidia.com/ov-web-sdk/latest/web-sample/overview.html) in the OV Web SDK. It is the actively maintained replacement for this sample.
+
+Rather than cloning one fixed sample, the Create OV WebRTC sample scaffolds a fresh, ready-to-run web streaming client on demand with `npx`. It tracks a pinned, versioned NVIDIA Web Streaming Library, supports local, Omniverse Kit App Streaming (OKAS), and NVCF cloud streaming backends, and lets you generate a TypeScript-only or React project.
+
 <p align="center">
   <img src="readme-assets/sample.png" width=100% />
 </p>


### PR DESCRIPTION
Adds a deprecation notice to the top of the README.

This repository is no longer actively developed or updated. The notice points readers to the Create OV WebRTC sample in the OV Web SDK as the actively maintained replacement: https://docs.omniverse.nvidia.com/ov-web-sdk/latest/web-sample/overview.html

Format follows the existing NVIDIA-Omniverse convention used by clash-detection-samples and configurator-samples (a `## :warning: Deprecation Notice` heading directly under the title).